### PR TITLE
Relay IPC events to WebSocket clients and harden renderer bridge

### DIFF
--- a/core-app/main/preload.js
+++ b/core-app/main/preload.js
@@ -14,7 +14,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   
   // Send sphere updates to main process
   sendSphereUpdate: (data) => ipcRenderer.send('sphere-update', data),
-  
+  sendSliceUpdate: (data) => ipcRenderer.send('slice-update', data),
+  sendMediaControl: (data) => ipcRenderer.send('media-control', data),
+
   // Remove all listeners
   removeAllListeners: () => ipcRenderer.removeAllListeners()
 });


### PR DESCRIPTION
## Summary
- expose renderer-to-main IPC helpers for slice and media controls in the preload bridge
- relay sphere, slice, and media updates from both IPC and WebSocket sources to the renderer and all connected clients
- guard renderer IPC calls until the preload bridge is ready so UI interactions stay responsive

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d92a1a5204832cad300498b9217df0