### PR TITLE
Implement dataset streaming pipeline

### DIFF
--- a/core-app/main/main.js
+++ b/core-app/main/main.js
@@ -1,11 +1,65 @@
 const { app, BrowserWindow, ipcMain, screen } = require('electron');
 const path = require('path');
+const { pathToFileURL } = require('url');
 const WSServer = require('../src/ws-server');
 const SphereControl = require('../src/sphere-control');
 
 let mainWindow;
 let wsServer;
 let sphereControl;
+
+const DATASETS = [
+  {
+    id: 'dataset1',
+    name: 'Earth Day and Night',
+    type: 'image',
+    file: 'earth-day-night.jpg',
+    description: 'Earth showing day and night regions',
+    projection: 'sphere'
+  },
+  {
+    id: 'dataset2',
+    name: 'Ocean Currents',
+    type: 'video',
+    file: 'ocean-currents.mp4',
+    description: 'Global ocean current patterns',
+    projection: 'sphere',
+    streaming: {
+      loop: true,
+      muted: true
+    }
+  },
+  {
+    id: 'dataset3',
+    name: 'Temperature Map',
+    type: 'image',
+    file: 'temperature-map.jpg',
+    description: 'Global temperature distribution',
+    projection: 'sphere'
+  }
+];
+
+function resolveDatasetDescriptor(dataset) {
+  if (!dataset) {
+    return null;
+  }
+
+  const assetPath = path.resolve(__dirname, '../assets', dataset.file);
+  const descriptor = {
+    id: dataset.id,
+    name: dataset.name,
+    type: dataset.type,
+    description: dataset.description,
+    projection: dataset.projection || 'sphere',
+    uri: pathToFileURL(assetPath).href
+  };
+
+  if (dataset.streaming) {
+    descriptor.streaming = dataset.streaming;
+  }
+
+  return descriptor;
+}
 
 function createWindow() {
   // Get primary display dimensions
@@ -81,7 +135,17 @@ function initializeWSServer() {
   
   // Handle dataset loading
   wsServer.on('load-dataset', (data) => {
-    if (mainWindow) {
+    if (!mainWindow) {
+      return;
+    }
+
+    const datasetId = typeof data === 'string' ? data : data?.id;
+    const dataset = DATASETS.find(d => d.id === datasetId);
+    const descriptor = resolveDatasetDescriptor(dataset);
+
+    if (descriptor) {
+      mainWindow.webContents.send('load-dataset', descriptor);
+    } else if (data && data.uri) {
       mainWindow.webContents.send('load-dataset', data);
     }
   });
@@ -105,37 +169,33 @@ function initializeSphereControl() {
 }
 
 // IPC handlers
-ipcMain.handle('get-datasets', async () => {
-  // Return list of available datasets
-  return [
-    {
-      id: 'dataset1',
-      name: 'Earth Day and Night',
-      type: 'image',
-      path: './assets/earth-day-night.jpg',
-      description: 'Earth showing day and night regions'
-    },
-    {
-      id: 'dataset2',
-      name: 'Ocean Currents',
-      type: 'video',
-      path: './assets/ocean-currents.mp4',
-      description: 'Global ocean current patterns'
-    },
-    {
-      id: 'dataset3',
-      name: 'Temperature Map',
-      type: 'image',
-      path: './assets/temperature-map.jpg',
-      description: 'Global temperature distribution'
-    }
-  ];
-});
+ipcMain.handle('get-datasets', async () =>
+  DATASETS.map(({ id, name, type, description }) => ({
+    id,
+    name,
+    type,
+    description
+  }))
+);
 
 ipcMain.handle('load-dataset', async (event, datasetId) => {
-  // Load the specified dataset
-  console.log(`Loading dataset: ${datasetId}`);
-  return { success: true };
+  const dataset = DATASETS.find(d => d.id === datasetId);
+
+  if (!dataset) {
+    const errorMessage = `Dataset not found: ${datasetId}`;
+    console.error(errorMessage);
+    return { success: false, error: errorMessage };
+  }
+
+  const descriptor = resolveDatasetDescriptor(dataset);
+
+  if (descriptor && mainWindow) {
+    mainWindow.webContents.send('load-dataset', descriptor);
+  }
+
+  console.log(`Loaded dataset: ${datasetId}`);
+
+  return descriptor;
 });
 
 // App event handlers

--- a/core-app/renderer/js/three-renderer.js
+++ b/core-app/renderer/js/three-renderer.js
@@ -6,10 +6,17 @@ class SphereRenderer {
     this.scene = null;
     this.camera = null;
     this.renderer = null;
-    this.sphere = null;
-    this.cubeCamera = null;
-    this.outputPlane = null;
-    
+    this.sphereMesh = null;
+    this.planeMesh = null;
+    this.sphereMaterial = null;
+    this.planeMaterial = null;
+
+    this.activeTexture = null;
+    this.activeVideoTexture = null;
+    this.activeVideoElement = null;
+
+    this.currentProjection = 'sphere';
+
     this.sphereState = {
       rotation: { x: 0, y: 0 },
       zoom: 0,
@@ -19,174 +26,303 @@ class SphereRenderer {
         overlap: 0
       }
     };
-    
+
     this.sliceStates = new Map();
-    
+
+    this.animate = this.animate.bind(this);
+
     this.init();
   }
-  
+
   init() {
-    // Initialize Three.js components
+    this.setupRenderer();
     this.setupScene();
     this.setupCamera();
-    this.setupRenderer();
-    this.setupSphere();
-    this.setupCubeCamera();
-    this.setupOutputPlane();
-    
-    // Start animation loop
-    this.animate();
-    
-    // Hide loading indicator
+    this.setupMeshes();
+    this.handleResize();
+
+    window.addEventListener('resize', () => this.handleResize());
+
+    this.animationFrameId = requestAnimationFrame(this.animate);
+
     const loadingIndicator = document.getElementById('loading-indicator');
     if (loadingIndicator) {
       loadingIndicator.style.display = 'none';
     }
   }
-  
+
+  setupRenderer() {
+    const contextOptions = {
+      canvas: this.canvas,
+      antialias: true,
+      alpha: true,
+      powerPreference: 'high-performance'
+    };
+
+    this.renderer = new THREE.WebGLRenderer(contextOptions);
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    this.renderer.setSize(this.canvas.clientWidth, this.canvas.clientHeight, false);
+    this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+  }
+
   setupScene() {
     this.scene = new THREE.Scene();
     this.scene.background = new THREE.Color(0x000000);
   }
-  
+
   setupCamera() {
-    this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
-    this.camera.position.z = 1;
+    const aspect = this.canvas.clientWidth / Math.max(1, this.canvas.clientHeight);
+    this.camera = new THREE.PerspectiveCamera(60, aspect, 0.1, 100);
+    this.camera.position.set(0, 0, 2.2);
   }
-  
-  setupRenderer() {
-    this.renderer = new THREE.WebGLRenderer({
-      canvas: this.canvas,
-      antialias: true,
-      alpha: true
-    });
-    
-    this.renderer.setSize(this.canvas.clientWidth, this.canvas.clientHeight);
-    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-    
-    // Handle window resize
-    window.addEventListener('resize', () => this.handleResize());
-  }
-  
-  setupSphere() {
-    const geometry = new THREE.SphereGeometry(10, 64, 32);
-    const material = new THREE.MeshBasicMaterial({
-      color: 0x888888,
+
+  setupMeshes() {
+    const sphereGeometry = new THREE.SphereGeometry(1, 128, 64);
+    this.sphereMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffffff,
       side: THREE.BackSide
     });
-    
-    this.sphere = new THREE.Mesh(geometry, material);
-    this.scene.add(this.sphere);
-  }
-  
-  setupCubeCamera() {
-    this.cubeCamera = new THREE.CubeCamera(1, 1000, 2048);
-    this.scene.add(this.cubeCamera);
-  }
-  
-  setupOutputPlane() {
-    const vertexShader = `
-      varying vec2 vUv;
-      void main() {
-        vUv = uv;
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-      }
-    `;
-    
-    const fragmentShader = `
-      uniform samplerCube tCube;
-      varying vec2 vUv;
-      const float PI = 3.141592653589793;
-      
-      void main() {
-        float lon = vUv.x * 2.0 * PI - PI;
-        float lat = vUv.y * PI;
-        float x = cos(lat) * sin(lon);
-        float y = sin(lat);
-        float z = cos(lat) * cos(lon);
-        vec3 direction = normalize(vec3(x, y, z));
-        gl_FragColor = textureCube(tCube, direction);
-      }
-    `;
-    
-    const planeGeometry = new THREE.PlaneGeometry(2, 2);
-    const planeMaterial = new THREE.ShaderMaterial({
-      uniforms: {
-        tCube: { value: this.cubeCamera.renderTarget.texture }
-      },
-      vertexShader,
-      fragmentShader,
+    this.sphereMesh = new THREE.Mesh(sphereGeometry, this.sphereMaterial);
+    this.scene.add(this.sphereMesh);
+
+    const planeGeometry = new THREE.PlaneGeometry(2, 1);
+    this.planeMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffffff,
       side: THREE.DoubleSide
     });
-    
-    this.outputPlane = new THREE.Mesh(planeGeometry, planeMaterial);
-    this.scene.add(this.outputPlane);
+    this.planeMesh = new THREE.Mesh(planeGeometry, this.planeMaterial);
+    this.planeMesh.visible = false;
+    this.scene.add(this.planeMesh);
   }
-  
+
+  async loadDataset(descriptor) {
+    await this.disposeActiveMedia();
+
+    this.currentProjection = descriptor?.projection || 'sphere';
+
+    if (!descriptor || !descriptor.uri) {
+      throw new Error('Invalid dataset descriptor received');
+    }
+
+    if (descriptor.type === 'video') {
+      const { texture, element } = await this.createVideoTexture(descriptor);
+      this.applyTexture(texture);
+      this.activeVideoTexture = texture;
+      this.activeVideoElement = element;
+      return { mediaElement: element };
+    }
+
+    const texture = await this.createImageTexture(descriptor);
+    this.applyTexture(texture);
+    this.activeTexture = texture;
+
+    return { mediaElement: null };
+  }
+
+  async createImageTexture(descriptor) {
+    const loader = new THREE.TextureLoader();
+
+    const texture = await loader.loadAsync(descriptor.uri);
+    texture.colorSpace = THREE.SRGBColorSpace;
+    texture.wrapS = THREE.RepeatWrapping;
+    texture.wrapT = THREE.ClampToEdgeWrapping;
+    texture.minFilter = THREE.LinearFilter;
+    texture.magFilter = THREE.LinearFilter;
+
+    this.configureTextureForHighResolution(texture);
+
+    return texture;
+  }
+
+  async createVideoTexture(descriptor) {
+    const video = document.createElement('video');
+    video.src = descriptor.uri;
+    video.crossOrigin = 'anonymous';
+    const streaming = descriptor.streaming || {};
+    video.loop = streaming.loop ?? true;
+    video.muted = streaming.muted ?? false;
+    const initialVolume = streaming.muted ? 0 : (typeof streaming.volume === 'number' ? streaming.volume : 1);
+    video.volume = THREE.MathUtils.clamp(initialVolume, 0, 1);
+    video.preload = descriptor.streaming?.preload ?? 'auto';
+    video.playsInline = true;
+    video.controls = false;
+    video.style.display = 'none';
+    document.body.appendChild(video);
+
+    await new Promise((resolve, reject) => {
+      const cleanup = () => {
+        video.removeEventListener('loadeddata', onLoadedData);
+        video.removeEventListener('error', onError);
+      };
+
+      const onLoadedData = () => {
+        cleanup();
+        resolve();
+      };
+
+      const onError = (event) => {
+        cleanup();
+        reject(new Error(`Failed to load video: ${event?.message || descriptor.uri}`));
+      };
+
+      video.addEventListener('loadeddata', onLoadedData, { once: true });
+      video.addEventListener('error', onError, { once: true });
+    });
+
+    const texture = new THREE.VideoTexture(video);
+    texture.colorSpace = THREE.SRGBColorSpace;
+    texture.wrapS = THREE.RepeatWrapping;
+    texture.wrapT = THREE.ClampToEdgeWrapping;
+    texture.minFilter = THREE.LinearFilter;
+    texture.magFilter = THREE.LinearFilter;
+    texture.generateMipmaps = false;
+
+    this.configureTextureForHighResolution(texture);
+
+    return { texture, element: video };
+  }
+
+  configureTextureForHighResolution(texture) {
+    if (!this.renderer || !texture) {
+      return;
+    }
+
+    const capabilities = this.renderer.capabilities;
+    if (capabilities && typeof capabilities.getMaxAnisotropy === 'function') {
+      texture.anisotropy = capabilities.getMaxAnisotropy();
+    }
+
+    texture.needsUpdate = true;
+  }
+
+  applyTexture(texture) {
+    if (this.currentProjection === 'plane') {
+      this.sphereMesh.visible = false;
+      this.planeMesh.visible = true;
+      this.planeMaterial.map = texture;
+      this.planeMaterial.needsUpdate = true;
+    } else {
+      this.planeMesh.visible = false;
+      this.sphereMesh.visible = true;
+      this.sphereMaterial.map = texture;
+      this.sphereMaterial.needsUpdate = true;
+    }
+
+    this.updateSphere({
+      rotation: { ...this.sphereState.rotation },
+      zoom: this.sphereState.zoom
+    });
+  }
+
+  async disposeActiveMedia() {
+    if (this.activeVideoElement) {
+      this.activeVideoElement.pause();
+      this.activeVideoElement.removeAttribute('src');
+      this.activeVideoElement.load();
+      this.activeVideoElement.remove();
+      this.activeVideoElement = null;
+    }
+
+    if (this.activeVideoTexture) {
+      this.activeVideoTexture.dispose();
+      this.activeVideoTexture = null;
+    }
+
+    if (this.activeTexture) {
+      this.activeTexture.dispose();
+      this.activeTexture = null;
+    }
+
+    if (this.sphereMaterial) {
+      this.sphereMaterial.map = null;
+    }
+
+    if (this.planeMaterial) {
+      this.planeMaterial.map = null;
+    }
+  }
+
   updateSphere(state) {
     this.sphereState = { ...this.sphereState, ...state };
-    
-    if (this.sphere) {
-      this.sphere.rotation.x = THREE.MathUtils.degToRad(this.sphereState.rotation.x);
-      this.sphere.rotation.y = THREE.MathUtils.degToRad(this.sphereState.rotation.y);
-      
-      // Update zoom by adjusting camera position
-      const zoomDistance = this.sphereState.zoom * 10;
-      const direction = new THREE.Vector3(0, 0, 1);
-      this.cubeCamera.position.copy(direction.multiplyScalar(zoomDistance));
+
+    const rotation = this.sphereState.rotation || {};
+    const xRotation = THREE.MathUtils.degToRad(rotation.x || 0);
+    const yRotation = THREE.MathUtils.degToRad(rotation.y || 0);
+
+    if (this.sphereMesh) {
+      this.sphereMesh.rotation.x = xRotation;
+      this.sphereMesh.rotation.y = yRotation;
+    }
+
+    if (this.planeMesh) {
+      this.planeMesh.rotation.x = xRotation;
+      this.planeMesh.rotation.y = yRotation;
+    }
+
+    const zoom = THREE.MathUtils.clamp(this.sphereState.zoom || 0, 0, 1);
+    const baseDistance = this.currentProjection === 'plane' ? 2.4 : 1.8;
+    const zoomRange = this.currentProjection === 'plane' ? 1.2 : 1.4;
+    const targetZ = Math.max(0.6, baseDistance - zoom * zoomRange);
+
+    if (this.camera) {
+      this.camera.position.z = targetZ;
     }
   }
-  
+
   updateSlice(sliceId, state) {
     this.sliceStates.set(sliceId, state);
-    // Handle slice-specific rendering logic
   }
-  
-  loadTexture(texture) {
-    if (this.sphere && this.sphere.material) {
-      this.sphere.material.map = texture;
-      this.sphere.material.needsUpdate = true;
-    }
-  }
-  
+
   handleResize() {
-    if (this.renderer && this.camera) {
-      this.renderer.setSize(this.canvas.clientWidth, this.canvas.clientHeight);
-      
-      // Update orthographic camera
-      const aspect = this.canvas.clientWidth / this.canvas.clientHeight;
-      this.camera.left = -aspect;
-      this.camera.right = aspect;
-      this.camera.updateProjectionMatrix();
+    if (!this.renderer || !this.camera) {
+      return;
     }
+
+    const width = this.canvas.clientWidth || this.canvas.width || 1;
+    const height = this.canvas.clientHeight || this.canvas.height || 1;
+
+    this.renderer.setSize(width, height, false);
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
   }
-  
+
   animate() {
-    requestAnimationFrame(() => this.animate());
-    
-    // Update cube camera
-    if (this.cubeCamera) {
-      this.cubeCamera.update(this.renderer, this.scene);
+    if (this.activeVideoTexture) {
+      this.activeVideoTexture.needsUpdate = true;
     }
-    
-    // Render scene
+
     if (this.renderer && this.scene && this.camera) {
       this.renderer.render(this.scene, this.camera);
     }
+
+    this.animationFrameId = requestAnimationFrame(this.animate);
   }
-  
+
   dispose() {
+    if (this.animationFrameId) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
+    }
+
     if (this.renderer) {
       this.renderer.dispose();
     }
-    
-    if (this.sphere && this.sphere.geometry) {
-      this.sphere.geometry.dispose();
+
+    if (this.sphereMesh) {
+      this.sphereMesh.geometry.dispose();
+      if (this.sphereMesh.material) {
+        this.sphereMesh.material.dispose();
+      }
     }
-    
-    if (this.sphere && this.sphere.material) {
-      this.sphere.material.dispose();
+
+    if (this.planeMesh) {
+      this.planeMesh.geometry.dispose();
+      if (this.planeMesh.material) {
+        this.planeMesh.material.dispose();
+      }
     }
+
+    this.disposeActiveMedia();
   }
 }
 

--- a/core-app/renderer/js/ui-controller.js
+++ b/core-app/renderer/js/ui-controller.js
@@ -2,7 +2,8 @@ class UIController {
   constructor() {
     this.currentDataset = null;
     this.datasets = [];
-    
+    this.mediaElement = null;
+
     this.init();
   }
   
@@ -10,6 +11,7 @@ class UIController {
     this.setupEventListeners();
     this.loadDatasets();
     this.setupIPCListeners();
+    this.configureMediaControls();
   }
   
   setupEventListeners() {
@@ -53,19 +55,24 @@ class UIController {
     
     // Media controls
     document.getElementById('play-btn').addEventListener('click', () => {
+      this.controlMediaElement('play');
       this.sendMediaControl('play');
     });
-    
+
     document.getElementById('pause-btn').addEventListener('click', () => {
+      this.controlMediaElement('pause');
       this.sendMediaControl('pause');
     });
-    
+
     document.getElementById('stop-btn').addEventListener('click', () => {
+      this.controlMediaElement('stop');
       this.sendMediaControl('stop');
     });
-    
+
     document.getElementById('volume').addEventListener('input', (e) => {
-      this.sendMediaControl('volume', parseFloat(e.target.value) / 100);
+      const level = parseFloat(e.target.value) / 100;
+      this.controlMediaElement('volume', level);
+      this.sendMediaControl('volume', level);
     });
   }
   
@@ -129,9 +136,14 @@ class UIController {
   async loadDataset(datasetId) {
     try {
       if (window.electronAPI) {
-        await window.electronAPI.loadDataset(datasetId);
-        
-        // Update UI
+        const descriptor = await window.electronAPI.loadDataset(datasetId);
+
+        if (descriptor && descriptor.success === false) {
+          this.showNotification('Failed to load dataset', 'error');
+          return;
+        }
+
+        // Update UI immediately
         const dataset = this.datasets.find(d => d.id === datasetId);
         if (dataset) {
           this.currentDataset = dataset;
@@ -197,15 +209,88 @@ class UIController {
   }
   
   handleMediaControl(data) {
-    // Handle media control updates
-    console.log('Media control:', data);
+    if (!data) {
+      return;
+    }
+
+    this.controlMediaElement(data.action, data.value);
+  }
+
+  controlMediaElement(action, value = null) {
+    if (!this.mediaElement) {
+      return;
+    }
+
+    switch (action) {
+      case 'play':
+        this.mediaElement.play().catch(() => {});
+        break;
+      case 'pause':
+        this.mediaElement.pause();
+        break;
+      case 'stop':
+        this.mediaElement.pause();
+        this.mediaElement.currentTime = 0;
+        break;
+      case 'volume':
+        if (typeof value === 'number') {
+          this.mediaElement.volume = Math.min(1, Math.max(0, value));
+          this.mediaElement.muted = this.mediaElement.volume === 0;
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  configureMediaControls() {
+    const isVideo = !!this.mediaElement;
+    const controls = [
+      document.getElementById('play-btn'),
+      document.getElementById('pause-btn'),
+      document.getElementById('stop-btn')
+    ];
+
+    controls.forEach(control => {
+      if (control) {
+        control.disabled = !isVideo;
+      }
+    });
+
+    const volume = document.getElementById('volume');
+    if (volume) {
+      volume.disabled = !isVideo;
+      if (isVideo && this.mediaElement) {
+        const effectiveVolume = this.mediaElement.muted ? 0 : this.mediaElement.volume;
+        volume.value = Math.round(effectiveVolume * 100);
+      }
+    }
   }
   
-  handleDatasetLoaded(data) {
-    if (data.success) {
-      this.showNotification('Dataset loaded successfully', 'success');
-    } else {
+  async handleDatasetLoaded(dataset) {
+    if (!dataset || dataset.success === false) {
       this.showNotification('Failed to load dataset', 'error');
+      return;
+    }
+
+    try {
+      if (window.sphereRenderer) {
+        const result = await window.sphereRenderer.loadDataset(dataset);
+        this.mediaElement = result?.mediaElement || null;
+      }
+
+      const datasetMeta = this.datasets.find(d => d.id === dataset.id) || dataset;
+      this.currentDataset = datasetMeta;
+      this.updateDatasetInfo(datasetMeta);
+      this.highlightDataset(dataset.id);
+      this.configureMediaControls();
+
+      this.showNotification(`Dataset "${dataset.name || dataset.id}" loaded`, 'success');
+    } catch (error) {
+      console.error('Failed to load dataset in renderer', error);
+      this.mediaElement = null;
+      this.configureMediaControls();
+      this.showNotification('Failed to display dataset', 'error');
     }
   }
   


### PR DESCRIPTION
## Summary
- resolve dataset metadata into file-based descriptors in the main process and share them over IPC and WebSocket events
- update the renderer controller to load textures, manage dataset UI state, and drive shared playback controls
- refactor the Three.js renderer to support image and video textures, plane projection, and video texture updates

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_b_68d92a224160832ca6a31181100a693c