### PR TITLE
feat: add dataset catalogs and admin refresh tooling

### DIFF
--- a/core-app/assets/catalogs/imagery.json
+++ b/core-app/assets/catalogs/imagery.json
@@ -1,0 +1,21 @@
+{
+  "catalog": "Imagery",
+  "datasets": [
+    {
+      "id": "earth-day-night",
+      "name": "Earth Day and Night",
+      "mediaType": "image",
+      "format": "image/jpeg",
+      "sourceUri": "./assets/earth-day-night.jpg",
+      "description": "Earth showing day and night regions"
+    },
+    {
+      "id": "temperature-map",
+      "name": "Temperature Map",
+      "mediaType": "image",
+      "format": "image/jpeg",
+      "sourceUri": "./assets/temperature-map.jpg",
+      "description": "Global temperature distribution"
+    }
+  ]
+}

--- a/core-app/assets/catalogs/media.json
+++ b/core-app/assets/catalogs/media.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "ocean-currents",
+    "name": "Ocean Currents",
+    "mediaType": "video",
+    "format": "video/mp4",
+    "sourceUri": "./assets/ocean-currents.mp4",
+    "description": "Global ocean current patterns"
+  },
+  {
+    "id": "aurora-stream",
+    "name": "Aurora Live Stream",
+    "mediaType": "stream",
+    "format": "video/hls",
+    "sourceUri": "https://example.com/aurora/playlist.m3u8",
+    "description": "Live aurora borealis imagery"
+  }
+]

--- a/core-app/main/preload.js
+++ b/core-app/main/preload.js
@@ -4,6 +4,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   // Dataset functions
   getDatasets: () => ipcRenderer.invoke('get-datasets'),
+  refreshDatasets: () => ipcRenderer.invoke('refresh-datasets'),
   loadDataset: (datasetId) => ipcRenderer.invoke('load-dataset', datasetId),
   
   // Event listeners

--- a/core-app/renderer/css/main.css
+++ b/core-app/renderer/css/main.css
@@ -156,6 +156,15 @@ body {
     background-color: #2563eb;
 }
 
+.btn-secondary {
+    background-color: #4b5563;
+    color: #ffffff;
+}
+
+.btn-secondary:hover {
+    background-color: #6b7280;
+}
+
 /* Media controls */
 .media-controls {
     display: flex;
@@ -220,6 +229,22 @@ body {
     padding: 0.75rem;
     font-size: 0.875rem;
     line-height: 1.4;
+}
+
+.dataset-origin {
+    font-size: 0.75rem;
+    color: #9ca3af;
+    margin-top: 0.5rem;
+}
+
+.empty-state {
+    padding: 1rem;
+    background-color: #2f2f2f;
+    border: 1px dashed #4b5563;
+    border-radius: 4px;
+    text-align: center;
+    color: #9ca3af;
+    font-size: 0.875rem;
 }
 
 .performance-info div {
@@ -321,6 +346,62 @@ body {
     align-items: center;
     font-size: 0.75rem;
     color: #b0b0b0;
+}
+
+/* Catalog management */
+.catalog-toolbar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.catalog-status {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    color: #9ca3af;
+}
+
+.catalog-directory {
+    word-break: break-all;
+}
+
+.catalog-errors {
+    background-color: #2f2f2f;
+    border: 1px solid #404040;
+    border-radius: 4px;
+    padding: 0.75rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.8125rem;
+    color: #d1d5db;
+}
+
+.catalog-errors.has-errors {
+    border-color: #b91c1c;
+    background-color: rgba(185, 28, 28, 0.15);
+    color: #fecaca;
+}
+
+.catalog-message {
+    color: inherit;
+}
+
+.catalog-error-list {
+    list-style: disc;
+    margin-left: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.catalog-error-list li {
+    line-height: 1.3;
+}
+
+.catalog-error-list .error-source {
+    font-weight: 600;
 }
 
 /* Scrollbar styling */

--- a/core-app/renderer/index.html
+++ b/core-app/renderer/index.html
@@ -22,6 +22,16 @@
             <aside class="control-panel">
                 <div class="panel-section">
                     <h2>Datasets</h2>
+                    <div class="catalog-toolbar">
+                        <button id="refresh-datasets" class="btn btn-secondary">Refresh catalogs</button>
+                        <div class="catalog-status">
+                            <span id="catalog-last-updated">Loading catalogs...</span>
+                            <span id="catalog-directory" class="catalog-directory"></span>
+                        </div>
+                    </div>
+                    <div id="catalog-errors" class="catalog-errors">
+                        <div class="catalog-message">No validation issues detected.</div>
+                    </div>
                     <div id="dataset-list" class="dataset-list">
                         <!-- Datasets will be loaded here -->
                     </div>

--- a/core-app/renderer/js/ui-controller.js
+++ b/core-app/renderer/js/ui-controller.js
@@ -2,16 +2,19 @@ class UIController {
   constructor() {
     this.currentDataset = null;
     this.datasets = [];
-    
+    this.catalogErrors = [];
+    this.catalogLastUpdated = null;
+    this.catalogDir = null;
+
     this.init();
   }
-  
+
   init() {
     this.setupEventListeners();
-    this.loadDatasets();
+    this.loadDatasets({ silent: true });
     this.setupIPCListeners();
   }
-  
+
   setupEventListeners() {
     // Sphere controls
     const rotationX = document.getElementById('rotation-x');
@@ -67,6 +70,13 @@ class UIController {
     document.getElementById('volume').addEventListener('input', (e) => {
       this.sendMediaControl('volume', parseFloat(e.target.value) / 100);
     });
+
+    const refreshCatalogs = document.getElementById('refresh-datasets');
+    if (refreshCatalogs) {
+      refreshCatalogs.addEventListener('click', () => {
+        this.loadDatasets({ refresh: true });
+      });
+    }
   }
   
   setupIPCListeners() {
@@ -93,64 +103,159 @@ class UIController {
     }
   }
   
-  async loadDatasets() {
+  async loadDatasets({ silent = false, refresh = false } = {}) {
     try {
       if (window.electronAPI) {
-        this.datasets = await window.electronAPI.getDatasets();
-        this.renderDatasetList();
+        const response = refresh
+          ? await window.electronAPI.refreshDatasets()
+          : await window.electronAPI.getDatasets();
+        this.applyCatalogResponse(response);
+
+        if (!silent) {
+          if (this.catalogErrors.length > 0) {
+            this.showNotification('Catalog reloaded with validation issues', 'warning');
+          } else {
+            this.showNotification('Catalogs refreshed successfully', 'success');
+          }
+        } else if (this.catalogErrors.length > 0) {
+          this.showNotification('Catalog validation issues detected', 'warning');
+        }
       }
     } catch (error) {
       this.showNotification('Failed to load datasets', 'error');
     }
   }
-  
+
+  applyCatalogResponse(response) {
+    if (!response) {
+      return;
+    }
+
+    this.datasets = Array.isArray(response.datasets) ? response.datasets : [];
+    this.catalogErrors = Array.isArray(response.errors) ? response.errors : [];
+    this.catalogLastUpdated = response.lastUpdated || null;
+    this.catalogDir = response.catalogDir || null;
+
+    this.renderDatasetList();
+    this.renderCatalogErrors();
+    this.updateCatalogStatus();
+  }
+
   renderDatasetList() {
     const datasetList = document.getElementById('dataset-list');
     datasetList.innerHTML = '';
-    
+
+    if (!this.datasets.length) {
+      const emptyState = document.createElement('div');
+      emptyState.className = 'empty-state';
+      emptyState.textContent = 'No datasets available.';
+      datasetList.appendChild(emptyState);
+      return;
+    }
+
     this.datasets.forEach(dataset => {
       const item = document.createElement('div');
       item.className = 'dataset-item';
       item.dataset.id = dataset.id;
-      
+
       item.innerHTML = `
         <div class="dataset-name">${dataset.name}</div>
-        <div class="dataset-type">${dataset.type}</div>
+        <div class="dataset-type">${dataset.mediaType}${dataset.format ? ` · ${dataset.format}` : ''}</div>
       `;
-      
+
       item.addEventListener('click', () => {
         this.loadDataset(dataset.id);
       });
-      
+
       datasetList.appendChild(item);
     });
+
+    if (this.currentDataset) {
+      this.highlightDataset(this.currentDataset.id);
+    }
   }
   
   async loadDataset(datasetId) {
     try {
       if (window.electronAPI) {
-        await window.electronAPI.loadDataset(datasetId);
-        
-        // Update UI
-        const dataset = this.datasets.find(d => d.id === datasetId);
-        if (dataset) {
-          this.currentDataset = dataset;
-          this.updateDatasetInfo(dataset);
-          this.highlightDataset(datasetId);
+        const result = await window.electronAPI.loadDataset(datasetId);
+
+        if (result && result.success) {
+          const dataset = result.dataset || this.datasets.find(d => d.id === datasetId);
+          if (dataset) {
+            this.currentDataset = dataset;
+            this.updateDatasetInfo(dataset);
+            this.highlightDataset(datasetId);
+          }
+          this.showNotification('Dataset loaded successfully', 'success');
+        } else {
+          const errorMessage = (result && result.error) || 'Failed to load dataset';
+          this.showNotification(errorMessage, 'error');
         }
       }
     } catch (error) {
       this.showNotification('Failed to load dataset', 'error');
     }
   }
-  
+
   updateDatasetInfo(dataset) {
     const info = document.getElementById('dataset-info');
     info.innerHTML = `
       <h3>${dataset.name}</h3>
-      <p><strong>Type:</strong> ${dataset.type}</p>
-      <p><strong>Description:</strong> ${dataset.description}</p>
+      <p><strong>Media Type:</strong> ${dataset.mediaType}</p>
+      ${dataset.format ? `<p><strong>Format:</strong> ${dataset.format}</p>` : ''}
+      <p><strong>Source:</strong> ${dataset.sourceUri}</p>
+      ${dataset.description ? `<p>${dataset.description}</p>` : ''}
+      ${dataset.catalogFile ? `<p class="dataset-origin">Catalog: ${dataset.catalogFile}</p>` : ''}
     `;
+  }
+
+  renderCatalogErrors() {
+    const container = document.getElementById('catalog-errors');
+    if (!container) {
+      return;
+    }
+
+    container.innerHTML = '';
+
+    if (!this.catalogErrors.length) {
+      const message = document.createElement('div');
+      message.className = 'catalog-message';
+      message.textContent = 'No validation issues detected.';
+      container.appendChild(message);
+      container.classList.remove('has-errors');
+      return;
+    }
+
+    container.classList.add('has-errors');
+
+    const list = document.createElement('ul');
+    list.className = 'catalog-error-list';
+
+    this.catalogErrors.forEach((error) => {
+      const item = document.createElement('li');
+      const source = error.file ? `${error.file}` : error.type;
+      const datasetInfo = error.datasetId ? ` (dataset: ${error.datasetId})` : '';
+      item.innerHTML = `<span class="error-source">${source}:</span> ${error.message}${datasetInfo}`;
+      list.appendChild(item);
+    });
+
+    container.appendChild(list);
+  }
+
+  updateCatalogStatus() {
+    const lastUpdated = document.getElementById('catalog-last-updated');
+    const directory = document.getElementById('catalog-directory');
+
+    if (lastUpdated) {
+      lastUpdated.textContent = this.catalogLastUpdated
+        ? `Last loaded: ${new Date(this.catalogLastUpdated).toLocaleString()}`
+        : 'Catalogs have not been loaded yet.';
+    }
+
+    if (directory) {
+      directory.textContent = this.catalogDir ? `Source: ${this.catalogDir}` : '';
+    }
   }
   
   highlightDataset(datasetId) {

--- a/core-app/src/catalog-manager.js
+++ b/core-app/src/catalog-manager.js
@@ -1,0 +1,224 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+const DEFAULT_CATALOG_DIR = path.join(__dirname, '../assets/catalogs');
+const MEDIA_TYPES = new Set(['image', 'video', 'stream', 'data', 'sequence']);
+
+class CatalogManager {
+  constructor(options = {}) {
+    this.catalogDir = options.catalogDir || process.env.AYNI_CATALOG_DIR || DEFAULT_CATALOG_DIR;
+    this.cache = null;
+    this.loadingPromise = null;
+  }
+
+  async getCatalogs() {
+    if (this.cache) {
+      return this._cloneCache();
+    }
+
+    if (!this.loadingPromise) {
+      this.loadingPromise = this._loadCatalogsFromDisk();
+    }
+
+    try {
+      await this.loadingPromise;
+    } finally {
+      this.loadingPromise = null;
+    }
+
+    return this._cloneCache();
+  }
+
+  async refreshCatalogs() {
+    this.cache = null;
+    return this.getCatalogs();
+  }
+
+  getDatasetById(datasetId) {
+    if (!this.cache) {
+      return null;
+    }
+    return this.cache.datasets.find((dataset) => dataset.id === datasetId) || null;
+  }
+
+  async _loadCatalogsFromDisk() {
+    const datasets = [];
+    const errors = [];
+    const seenIds = new Set();
+    const catalogDir = path.resolve(this.catalogDir);
+
+    try {
+      const stat = await fs.stat(catalogDir);
+      if (!stat.isDirectory()) {
+        errors.push({
+          type: 'directory',
+          message: `Catalog directory is not a folder: ${catalogDir}`
+        });
+        this.cache = { datasets: [], errors, lastUpdated: new Date().toISOString(), catalogDir };
+        return;
+      }
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        errors.push({
+          type: 'directory',
+          message: `Catalog directory does not exist: ${catalogDir}`
+        });
+        this.cache = { datasets: [], errors, lastUpdated: new Date().toISOString(), catalogDir };
+        return;
+      }
+      throw error;
+    }
+
+    const files = await fs.readdir(catalogDir);
+    const jsonFiles = files.filter((file) => file.toLowerCase().endsWith('.json'));
+
+    if (jsonFiles.length === 0) {
+      errors.push({
+        type: 'catalog',
+        message: `No catalog JSON files found in ${catalogDir}`
+      });
+    }
+
+    for (const fileName of jsonFiles) {
+      const filePath = path.join(catalogDir, fileName);
+      let payload;
+
+      try {
+        const fileContent = await fs.readFile(filePath, 'utf8');
+        payload = JSON.parse(fileContent);
+      } catch (error) {
+        errors.push({
+          type: 'parse',
+          file: fileName,
+          message: `Failed to parse JSON: ${error.message}`
+        });
+        continue;
+      }
+
+      const catalogDatasets = this._extractDatasets(payload);
+      if (!Array.isArray(catalogDatasets)) {
+        errors.push({
+          type: 'structure',
+          file: fileName,
+          message: 'Catalog JSON must be an array or contain a "datasets" array.'
+        });
+        continue;
+      }
+
+      catalogDatasets.forEach((dataset, index) => {
+        const validation = this._validateDataset(dataset);
+
+        if (!validation.valid) {
+          errors.push({
+            type: 'validation',
+            file: fileName,
+            datasetId: dataset && dataset.id,
+            message: `Dataset at index ${index}: ${validation.error}`
+          });
+          return;
+        }
+
+        if (seenIds.has(validation.dataset.id)) {
+          errors.push({
+            type: 'duplicate',
+            file: fileName,
+            datasetId: validation.dataset.id,
+            message: `Duplicate dataset id: ${validation.dataset.id}`
+          });
+          return;
+        }
+
+        seenIds.add(validation.dataset.id);
+        datasets.push({
+          ...validation.dataset,
+          catalogFile: fileName
+        });
+      });
+    }
+
+    this.cache = {
+      datasets,
+      errors,
+      lastUpdated: new Date().toISOString(),
+      catalogDir
+    };
+  }
+
+  _extractDatasets(payload) {
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+
+    if (payload && Array.isArray(payload.datasets)) {
+      return payload.datasets;
+    }
+
+    return null;
+  }
+
+  _validateDataset(rawDataset) {
+    if (typeof rawDataset !== 'object' || rawDataset === null) {
+      return { valid: false, error: 'Dataset entry must be an object.' };
+    }
+
+    const { id, name, mediaType, format, sourceUri, description, thumbnail } = rawDataset;
+
+    if (!id || typeof id !== 'string') {
+      return { valid: false, error: 'Missing required "id" (string).' };
+    }
+
+    if (!name || typeof name !== 'string') {
+      return { valid: false, error: 'Missing required "name" (string).' };
+    }
+
+    if (!mediaType || typeof mediaType !== 'string') {
+      return { valid: false, error: 'Missing required "mediaType" (string).' };
+    }
+
+    if (!MEDIA_TYPES.has(mediaType)) {
+      return {
+        valid: false,
+        error: `Unsupported mediaType "${mediaType}". Expected one of: ${Array.from(MEDIA_TYPES).join(', ')}.`
+      };
+    }
+
+    if (!sourceUri || typeof sourceUri !== 'string') {
+      return { valid: false, error: 'Missing required "sourceUri" (string).' };
+    }
+
+    if (format && typeof format !== 'string') {
+      return { valid: false, error: 'Optional "format" must be a string if provided.' };
+    }
+
+    if (description && typeof description !== 'string') {
+      return { valid: false, error: 'Optional "description" must be a string if provided.' };
+    }
+
+    if (thumbnail && typeof thumbnail !== 'string') {
+      return { valid: false, error: 'Optional "thumbnail" must be a string if provided.' };
+    }
+
+    return {
+      valid: true,
+      dataset: {
+        id,
+        name,
+        mediaType,
+        format: format || null,
+        sourceUri,
+        description: description || '',
+        thumbnail: thumbnail || null
+      }
+    };
+  }
+
+  _cloneCache() {
+    if (!this.cache) {
+      return { datasets: [], errors: [], lastUpdated: null, catalogDir: this.catalogDir };
+    }
+
+    return JSON.parse(JSON.stringify(this.cache));
+  }
+}
+
+module.exports = new CatalogManager();


### PR DESCRIPTION
## Summary
- add configurable JSON catalogs for media datasets and load them through a shared catalog manager
- replace the get-datasets IPC handler with validated, cached catalog loading and expose refresh support to the renderer
- enhance the control UI with catalog refresh controls, validation feedback, and richer dataset metadata styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d92a2af740832c95ce4726c3f3fa8f